### PR TITLE
Grunt upgrades and API improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Getting Started
 This plugin requires:
 
-	- grunt: "^0.4.5"
+	- grunt: "^1.0.1"
 	- grunt-shell
 
 **Important**: `grunt-shell` is a `peerDependency`. as NPM v3+ deprecates `peerDependencies`, you need to explicitly specify `grunt-shell` in your project's `devDependencies`:

--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ myapp:
 	image: ${DOCKER_REGISTRY}/${DOCKER_REGISTRY_NAMESPACE}/myapp:${TAG}
 ```
 
+#### options.mainService
+
+The name of your "main" service in the docker-compose file. This is the service whose logs will be tailed by default (and piped through `bunyan`) when doing `grunt logs`
+
+#### options.logTail
+
+How many lines of log to tail initially when starting to tail the logs. Defaults to 10.
 
 #### options.mappedComposeFile
 

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
+    "grunt": "^1.0.1",
     "grunt-concurrent": "^2.3.0",
-    "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-jshint": "^0.9.2",
-    "grunt-contrib-nodeunit": "^0.3.3",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-nodeunit": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-shell": "^1.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-docker-compose",
   "description": "Grunt plugin wrapping docker-compose commands",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "homepage": "https://github.com/YogaGlo/grunt-docker-compose",
   "author": {
     "name": "Eugene Brodsky",

--- a/tasks/dockerCompose.js
+++ b/tasks/dockerCompose.js
@@ -236,7 +236,7 @@ module.exports = function(grunt) {
 
 			// TODO This should use `docker-compose logs` when service name can be removed from the log entry, and `bunyan` cooperates
 			cmd = [
-				'docker logs --tail=0 -f',
+				'docker logs --tail=10 -f',
 				'$(',
 				// these are here just to avoid annoying warnings in the shell
 				'TAG=""',

--- a/tasks/dockerCompose.js
+++ b/tasks/dockerCompose.js
@@ -17,8 +17,6 @@ module.exports = function(grunt) {
 	var spawn = require('child_process').spawnSync;
 
 	var mergeConfig = function () {
-		pkg: grunt.file.readJSON('package.json'),
-
 		grunt.config.merge({
 			// TAG, DOCKER_REGISTRY, DOCKER_REGISTRY_NAMESPACE defaults
 			// May be overridden globally by exporting these env.vars to the shell,
@@ -26,6 +24,8 @@ module.exports = function(grunt) {
 			dockerCompose: {
 				options: {
 					tag: process.env.TAG,
+					logTail: grunt.config.get('dockerCompose.options.logTail') || "10",
+					mainService: grunt.config.get('dockerCompose.options.mainService') || grunt.file.readJSON('package.json').name,
 					dockerRegistry: process.env.DOCKER_REGISTRY,
 					dockerRegistryNamespace: process.env.DOCKER_REGISTRY_NAMESPACE,
 					composeFile: grunt.config.get('dockerCompose.options.composeFile') || 'docker-compose.yml',
@@ -228,15 +228,15 @@ module.exports = function(grunt) {
 		var bunyanExists = (spawn('which',['bunyan']).status === 0);
 
 		var cmd = buildCommandSkeleton();
-		cmd.push('docker-compose logs --tail=0 -f');
+		cmd.push('docker-compose logs --tail=<%= dockerCompose.options.logTail %> -f');
 
 		// If service is unspecified, only tail the main service's logs.
 		if (!service) {
-			service = '<%= pkg.name %>';
+			service = '<%= dockerCompose.options.mainService %>';
 
 			// TODO This should use `docker-compose logs` when service name can be removed from the log entry, and `bunyan` cooperates
 			cmd = [
-				'docker logs --tail=10 -f',
+				'docker logs --tail=<%= dockerCompose.options.logTail %> -f',
 				'$(',
 				// these are here just to avoid annoying warnings in the shell
 				'TAG=""',
@@ -336,7 +336,7 @@ module.exports = function(grunt) {
 		*/
 	grunt.registerTask('dockerComposeExec', 'Execute a command in a containter', function (service, exec) {
 		if (!service) {
-			service = '<%= pkg.name %>';
+			service = '<%= dockerCompose.options.mainService %>';
 		}
 
 		var cmd = buildCommandSkeleton();


### PR DESCRIPTION
- upgrades `grunt` dependencies to v1.0.1
- removes the `pkg.name` requirement, but leaves it as a fallback.
  - the new option is `mainService`. It may be specified if the name of the "main" service isn't equal to `(package.json).name` field
- adds logTail option. Defaults to 10 lines. May be set to specify the number of lines to tail initially when logging. This fixes the appearance of the log command "hanging" if there are no new lines to log.
