### PR TITLE
Fix infinite recursion when logging

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,7 +61,7 @@ module.exports = function(grunt) {
 					maxBuffer: Infinity
 				},
 				command: '<%= cmd %>'
-			},
+			}
 		},
 
 		// Unit tests.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "docker-compose"
   ],
   "dependencies": {
+    "async": "^2.0.1",
     "load-grunt-tasks": "^3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-docker-compose",
   "description": "Grunt plugin wrapping docker-compose commands",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/YogaGlo/grunt-docker-compose",
   "author": {
     "name": "Eugene Brodsky",
@@ -36,7 +36,6 @@
     "docker-compose"
   ],
   "dependencies": {
-    "async": "^2.0.1",
     "load-grunt-tasks": "^3.5.0"
   }
 }


### PR DESCRIPTION
If services are stopped or containers are killed/exited, the `logs` command will also exit instead of infinitely recursing
